### PR TITLE
improved node names and added lines-of-code per function

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -2,12 +2,16 @@ const { ScriptTarget } = require('typescript');
 const maintainability = require('./src/services/maintainability.service');
 const halstead = require('./src/services/halstead.service');
 const cyclomatic = require('./src/services/cyclomatic.service');
+const sloc = require('./src/services/sloc.service');
 
 exports.calculateMaintainability =
     filePath => maintainability.calculate(filePath, ScriptTarget.ES2015);
 
 exports.calculateHalstead =
     filePath => halstead.calculate(filePath, ScriptTarget.ES2015);
+
+exports.calculateSloc =
+    filePath => sloc.calculateSloc(filePath, ScriptTarget.ES2015);
 
 exports.calculateCyclomaticComplexity =
     filePath => cyclomatic.calculate(filePath, ScriptTarget.ES2015);

--- a/lib/src/services/cyclomatic.service.js
+++ b/lib/src/services/cyclomatic.service.js
@@ -2,7 +2,7 @@ const { forEachChild, SyntaxKind, createSourceFile } = require('typescript');
 const { isFunctionWithBody } = require('tsutils');
 const { existsSync, readFileSync } = require('fs');
 
-const getNodeName = require('../utilities/name.utility');
+const { getNodeName } = require('../utilities/name.utility');
 
 const increasesComplexity = (node) => {
     /* eslint-disable indent */
@@ -42,7 +42,7 @@ const calculateFromSource = (ctx) => {
             const old = complexity;
             complexity = 1;
             forEachChild(node, cb);
-            const name = getNodeName(node);
+            const name = getNodeName(node,ctx);
             output[name] = complexity;
             complexity = old;
         } else {

--- a/lib/src/services/halstead.service.js
+++ b/lib/src/services/halstead.service.js
@@ -2,7 +2,7 @@ const { forEachChild, SyntaxKind, createSourceFile } = require('typescript');
 const { isFunctionWithBody } = require('tsutils');
 const { existsSync, readFileSync } = require('fs');
 
-const getNodeName = require('../utilities/name.utility');
+const { getNodeName } = require('../utilities/name.utility');
 
 const isIdentifier = kind => kind === SyntaxKind.Identifier;
 const isLiteral = kind =>
@@ -83,7 +83,7 @@ const calculateFromSource = (ctx) => {
     const output = {};
     forEachChild(ctx, function cb(node) {
         if (isFunctionWithBody(node)) {
-            const name = getNodeName(node);
+            const name = getNodeName(node,ctx);
             output[name] = getHalstead(node);
         }
         forEachChild(node, cb);

--- a/lib/src/services/sloc.service.js
+++ b/lib/src/services/sloc.service.js
@@ -1,10 +1,17 @@
+
+const { forEachChild, SyntaxKind, createSourceFile } = require('typescript');
+const { isFunctionWithBody } = require('tsutils');
+const { existsSync, readFileSync, writeFileSync } = require('fs');
+
+const { getNodeName } = require('../utilities/name.utility');
+
 const getComments = (text) => {
     // Regex that matches all the strigns starting with //
     const singleLineCommentsRegex = /\/\*[\s\S]*?\*\/|([^\\:]|^)\/\/.*$/gm;
     return text ? (text.match(singleLineCommentsRegex) || []) : [];
 };
 
-exports.calculate = (sourceText) => {
+const calculate = (sourceText) => {
     const comments = getComments(sourceText);
     /* eslint-disable no-plusplus, no-param-reassign */
     for (let i = 0; i < comments.length; i++) {
@@ -12,6 +19,40 @@ exports.calculate = (sourceText) => {
         sourceText = (sourceText.replace(aMatched, '')).trim();
     }
     /* eslint-enable no-plusplus, no-param-reassign */
-    // console.log(sourceText);
     return (sourceText.split('\n').map(aLine => aLine.trim()).filter(aLine => !!aLine).length);
 };
+
+const getFunctionSLOC = (node, text) => {
+    let lines = -1;
+    if (typeof node.pos === 'number' && typeof node.end === 'number' &&
+        node.pos >= 0 && node.end <= text.length ) {
+        lines = calculate(text.substring(node.pos, node.end));
+    }
+    return lines;
+}
+
+const calculateFromSource = (ctx) => {
+    const output = {};
+    const text = ctx.text;
+    forEachChild(ctx, function cb(node) {
+        if (isFunctionWithBody(node)) {
+            const name = getNodeName(node,ctx);
+            output[name] = getFunctionSLOC(node, text);
+        }
+        forEachChild(node, cb);
+    });
+    return output;
+};
+
+exports.calculate = calculate;
+exports.calculateFromSource = calculateFromSource;
+
+exports.calculateSloc = (filePath, target) => {
+    if (!existsSync(filePath)) {
+        throw new Error(`File "${filePath}" does not exists`);
+    }
+    const sourceText = readFileSync(filePath).toString();
+    const source = createSourceFile(filePath, sourceText, target);
+
+    return calculateFromSource(source);
+}

--- a/lib/src/utilities/name.utility.js
+++ b/lib/src/utilities/name.utility.js
@@ -1,10 +1,78 @@
+
+const fs = require('fs');
 const { isIdentifier } = require('typescript');
 
-module.exports = (node) => {
+module.exports = { getNodeName };
+
+let visitedNodes = { };
+
+function getNodeName(node, ctx) {
+    const nodeName = getIdentifierName(node);
+    visitedNodes = { };
+    if (nodeName.includes("@")) {
+        const initializerName = getInitializerName(node, ctx);
+        if (initializerName) {
+            return initializerName;
+        }
+    }
+    return nodeName;
+}
+
+function getIdentifierName(node) {
     const { name, pos, end } = node;
     const key =
         (name !== undefined && isIdentifier(name))
             ? name.text
-            : JSON.stringify({ pos, end });
+            : `lambda @${pos}:${end}`;
     return key;
 };
+
+// function getInitializerName
+// traverse the parse tree to asscociate a lambda function with
+// the context in which it was declared, for example:
+//   const sum = (a,b) => a + b;              // name is "sum"
+//   list.forEach(item => console.log(item)); // name is "forEach"
+function getInitializerName(node, ctx, ancestorName, propertyName) {
+    if (!ctx || !node) {
+        return null;
+    }
+    if (typeof propertyName === 'undefined' )
+        propertyName = '';
+
+    if (ctx && typeof(ctx.pos)==='number' && typeof(ctx.end)==='number') {
+        const nodeID = `pos:${ctx.pos},end:${ctx.end},${Object.keys(ctx).toString()}`;
+        if (visitedNodes[nodeID]) {
+            // recursive reference detected
+            return null;
+        }
+        // why do arrays have pos and end properties?????
+        if (!Array.isArray(ctx)) {
+            visitedNodes[nodeID] = true;
+        }
+    }
+    let name = ctx?.name?.escapedText || ancestorName;
+
+    if (name && ctx && ctx.pos === node.pos && ctx.end === node.end) {
+        return `${name} @${ctx.pos}:${ctx.end}`;
+    }
+    else if (Array.isArray(ctx)) {
+        ancestorName = name;
+        name = null;
+        for (let i=0; i<ctx.length && !name; ++i) {
+            name = getInitializerName(node, ctx[i], ancestorName, `${i}`);
+        }
+        return name;
+    }
+    else if (typeof ctx === 'object') {
+        ancestorName = name;
+        name = null;
+        const keys = Object.keys(ctx);
+        for (let i=0; i<keys.length && !name; ++i) {
+            if (typeof ctx[keys[i]] === 'object') {
+                name = getInitializerName(node, ctx[keys[i]], ancestorName, keys[i]);
+            }
+        }
+        return name;
+    }
+}
+


### PR DESCRIPTION
This patch contains two changes:

1. The algorithm to discover a node (function) name has been improved. For example, previously the following const name initialization was not detected, but now it is:
`    const sum = (a,b) => a + b;`
Similarly, callback functions are named with the function they are passed into, e.g. forEach, like this:
`    myArray.forEach(item => console.log(item));`
Also, the default name for unnamed nodes has been modified.

2. The sloc service now reports lines of code per node (function), in addition to lines of code per file. The interface is exposed by a new export in main called `calculateSloc`.